### PR TITLE
Update pyproject.toml; update docs folder

### DIFF
--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -46,20 +46,21 @@ follow these [instructions](https://python-poetry.org/docs/master/#installation)
 
 
 
-## Installation
+## Installation and Virtual Environment Setup
 
- To install all your dependencies and activate your virtual environment,
-follow these steps:
-
-Install the dependencies
+If you want to install all your dependencies, including dependencies to help with developing your agent, run this command:
 
 ```poetry install```
 
-Set the environment to be in your project directory
+If you want to install only the dependencies needed to run your agent, run this command:
+
+```poetry install --no-dev```
+
+Set the environment to be in your project directory:
 
 ```poetry config virtualenvs.in-project true```
 
-Activate the virtual environment
+Activate the virtual environment:
 
 ```poetry shell```
 

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -50,3 +50,23 @@ python3.8 -m pip install --user pipx
 
 pipx install --python python3.8 [[ python_package_distribution_name ]]
 ```
+
+# Documentation
+
+To build the docs, navigate to the 'docs' directory and build the documentation:
+
+```shell
+cd docs
+make html
+```
+
+After the documentation is built, view the documentation in html form in your browser.
+The html files will be located in `~<path to agent project directory>/docs/build/html`.
+
+**PROTIP: To open the landing page of your documentation directly from the command line, run the following command:**
+
+```shell
+open <path to agent project directory>/docs/build/html/index.html
+```
+
+This will open the documentation landing page in your default browsert (e.g. Chrome, Firefox).

--- a/project/docs/requirements.txt.jinja
+++ b/project/docs/requirements.txt.jinja
@@ -1,6 +1,0 @@
-###### Requirements for [[ python_agent_class_name ]] docs ######
-
-sphinx_rtd_theme
-# sphinx-autobuild
-sphinx==4.4.0
-

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -22,6 +22,12 @@ mock = "^4.0.3"
 pre-commit = "^2.17.0"
 yapf = "^0.32.0"
 toml = "^0.10.2"
+isort = "^5.10.1"
+safety = "^1.10.3"
+mypy = "^0.942"
+coverage = "^6.3.2"
+Sphinx = "^4.5.0"
+sphinx-rtd-theme = "^1.0.0"
 
 [tool.yapfignore]
 ignore_patterns = [


### PR DESCRIPTION
* Puts sphinx dependencies in pyproject.toml so that users don't have to manually install sphinx to generate docs
* Updates README with instructions on how to use sphinx documentation
* Adds more dev-dependencies that are promised in README in https://github.com/VOLTTRON/copier-poetry-volttron-agent/pull/41/files

How tested:

I built a test agent using this branch. I tested out Makefile under docs. I also verified that the dev tools (e.g. safety, yapf, pre-commit, mypy) were working and properly installed. 

```
~/test-36/docs via test-36
➜ make html
Running Sphinx v4.5.0
making output directory... done
[autosummary] generating autosummary for: index.rst
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://www.sphinx-doc.org/en/master/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: [new config] 1 added, 0 changed, 0 removed
reading sources... [100%] index
/Users/boni407/test-36/docs/source/index.rst:16: WARNING: toctree contains reference to nonexisting document 'usage'
/Users/boni407/test-36/docs/source/index.rst:16: WARNING: toctree contains reference to nonexisting document 'agent'
/Users/boni407/test-36/docs/source/index.rst:16: WARNING: toctree contains reference to nonexisting document 'quick-start'
/Users/boni407/test-36/docs/source/index.rst:16: WARNING: toctree contains reference to nonexisting document 'fail-url-test-on-purpose'
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index
/Users/boni407/test-36/docs/source/index.rst:6: WARNING: unknown document: usage
/Users/boni407/test-36/docs/source/index.rst:6: WARNING: undefined label: installation
generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 6 warnings.

The HTML pages are in build/html.

====================== slowest reading durations =======================
0.027 index

~/test-36 via test-36 via 🐍 system 3.9.10
➜ which safety
/Users/boni407/test-36/.venv/bin/safety

~/test-36 via test-36 via 🐍 system 3.9.10
➜ which mypy
/Users/boni407/test-36/.venv/bin/mypy

~/test-36 via test-36 via 🐍 system 3.9.10
➜ which yapf
/Users/boni407/test-36/.venv/bin/yapf

~/test-36 via test-36 via 🐍 system 3.9.10
➜ which pre-commit
/Users/boni407/test-36/.venv/bin/pre-commit

~/test-36 via test-36 via 🐍 system 3.9.10
➜ which sphinx-build
/Users/boni407/test-36/.venv/bin/sphinx-build


```