### PR TITLE
Change classfiers

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -12,6 +12,9 @@ packages = [ { include = "[[ python_package_import_name ]]", from = "src" } ]
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Intended Audience :: Science/Research",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Other Audience",
     "License :: OSI Approved :: Apache Software License"
 ]
 [tool.poetry.dependencies]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -10,9 +10,9 @@ homepage = "https://[[ repository_provider ]]/[[ repository_namespace ]]/[[ repo
 keywords = []
 packages = [ { include = "[[ python_package_import_name ]]", from = "src" } ]
 classifiers = [
-    "Framework :: VOLTTRON",
-    "Framework :: VOLTTRON :: Agent",
-    "Framework :: VOLTTRON :: 0.1.0"
+    "Programming Language :: Python :: 3 :: Only",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License"
 ]
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"


### PR DESCRIPTION
Change the classifiers to the currently published classifiers in https://pypi.org/classifiers/.

Volttron-specific classifiers need to be added to https://pypi.org/classifiers/ before it can be used in a setup.py or pyproject.toml file. 