### PR TITLE
Hot fix/ to make logfn out of the box

### DIFF
--- a/project/src/[[ python_package_import_name ]]/agent.py.jinja
+++ b/project/src/[[ python_package_import_name ]]/agent.py.jinja
@@ -158,7 +158,8 @@ class [[ python_agent_class_name ]](Agent):
     @PubSub.subscribe('pubsub', '', all_platforms=True)
     def on_match(self, peer, sender, bus, topic, headers, message):
         """Use match_all to receive all messages and print them out."""
-        self._logfn(
+        _logfn = _log.info
+        _logfn(
             "Peer: {0}, Sender: {1}:, Bus: {2}, Topic: {3}, Headers: {4}, "
             "Message: \n{5}".format(peer, sender, bus, topic, headers, pformat(message)))
 

--- a/project/src/{{python_package_import_name }}/agent.py.jinja
+++ b/project/src/{{python_package_import_name }}/agent.py.jinja
@@ -158,8 +158,7 @@ class {{ python_agent_class_name }}(Agent):
     @PubSub.subscribe('pubsub', '', all_platforms=True)
     def on_match(self, peer, sender, bus, topic, headers, message):
         """Use match_all to receive all messages and print them out."""
-        _logfn = _log.info
-        _logfn(
+        _log.info(
             "Peer: {0}, Sender: {1}:, Bus: {2}, Topic: {3}, Headers: {4}, "
             "Message: \n{5}".format(peer, sender, bus, topic, headers, pformat(message)))
 


### PR DESCRIPTION
### Motivation
In https://github.com/VOLTTRON/copier-poetry-volttron-agent/blame/main/project/src/%7B%7Bpython_package_import_name%20%7D%7D/agent.py.jinja#L161-L163, the `self._logfn` is not defined and the created agent structure will run into errors.

### Solution
The modified version should create agent structure that can be installed out of the box.